### PR TITLE
Guard census.py#online_status_rest against an empty player map

### DIFF
--- a/modules/census.py
+++ b/modules/census.py
@@ -193,6 +193,9 @@ async def online_status_updater(chars_players_map_func):
 
 
 async def online_status_rest(chars_players_map):
+    if len(chars_players_map) == 0:
+        return True
+
     acc_char_ids = accounts.account_char_ids
 
     tracked_ids = list(acc_char_ids.keys()) + list(chars_players_map.keys())


### PR DESCRIPTION
Passing an empty player map to `census.py#online_status_rest` causes the construction of an invalid query, as there is an empty value for the `character_id` term. This PR resolves that by immediately returning a successful result when an empty map is passed.
This is an issue when deploying a fresh instance of the bot, with no registered users, and among other call sites, causes an error to be raised every iteration of the `admin.py#census_rest` loop task.