### PR TITLE
Add the 'stats' command

### DIFF
--- a/cogs/general.py
+++ b/cogs/general.py
@@ -110,7 +110,7 @@ class GeneralCog(commands.Cog, name="GeneralCog"):
                                                         ]
                                                     })
 
-        await ctx.respond(content=f"You've participated in {player_match_count} matches")
+        return await disp.STAT_RESPONSE.send_priv(ctx, player_match_count)
 
     @tasks.loop(seconds=5)
     async def activity_update(self):

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -42,7 +42,7 @@ class GeneralCog(commands.Cog, name="GeneralCog"):
         """Used to request freedom if you have been timed out from FSBot."""
         await ctx.defer(ephemeral=True)
         if not (p := d_obj.is_player(ctx.user)):
-            return await disp.NOT_PLAYER.send_priv(ctx, ctx.user.mention, d_obj.channels['register'].mention)
+            return await disp.NOT_PLAYER.send_priv(ctx, ctx.user.mention, d_obj.channels['register'])
         if p.timeout_until != 0 and not p.is_timeout:
             await d_obj.timeout_player(p=p, stamp=0)
             await disp.TIMEOUT_RELEASED.send_priv(ctx)

--- a/cogs/general.py
+++ b/cogs/general.py
@@ -41,7 +41,7 @@ class GeneralCog(commands.Cog, name="GeneralCog"):
         """Used to request freedom if you have been timed out from FSBot."""
         await ctx.defer(ephemeral=True)
         if not (p := d_obj.is_player(ctx.user)):
-            return await disp.NOT_PLAYER.send_priv(ctx, ctx.user.mention, d_obj.channels['register'])
+            return await disp.NOT_PLAYER.send_priv(ctx, ctx.user.mention, d_obj.channels['register'].mention)
         if p.timeout_until != 0 and not p.is_timeout:
             await d_obj.timeout_player(p=p, stamp=0)
             await disp.TIMEOUT_RELEASED.send_priv(ctx)

--- a/display/embeds.py
+++ b/display/embeds.py
@@ -204,6 +204,46 @@ def psb_account_usage(player, start_stamp, end_stamp, usages) -> Embed:
     return embed
 
 
+def stat_response(match_count: int, total_duel_sec: int, duel_partner_frequencies: dict) -> Embed:
+    # Local import to avoid circular dependency
+    from display import AllStrings
+
+    embed = Embed(
+        colour=Colour.blurple(),
+        title="Match Statistics",
+        description=AllStrings.STAT_TOTALS.value.format(match_count, round(total_duel_sec / 60 / 60, 1))
+    )
+
+    highest_partner = None
+    duel_partners = ""
+
+    for i in range(3):
+        if len(duel_partner_frequencies) == 0:
+            break
+
+        # Find the partner with which we've had the most matches
+        for partner_id, match_count in duel_partner_frequencies.items():
+            if highest_partner is None or highest_partner[1] < match_count:
+                highest_partner = (partner_id, match_count)
+
+        # Check if we selected a new highest partner
+        if highest_partner is None or highest_partner[0] not in duel_partner_frequencies:
+            continue
+
+        # We've found a new highest partner. Add them and move on
+        duel_partners += AllStrings.STAT_PARTNER_MATCH_COUNT.value.format(highest_partner[0], highest_partner[1])
+        duel_partners += "\n"
+        duel_partner_frequencies.pop(highest_partner[0])
+
+    if duel_partners != "":
+        embed.add_field(
+            name="Top Duel Partners",
+            value=duel_partners
+        )
+
+    return embed
+
+
 def player_info(player) -> Embed:
     embed = Embed(
         colour=Colour.greyple(),

--- a/display/strings.py
+++ b/display/strings.py
@@ -208,7 +208,10 @@ class AllStrings(Enum):
     USAGE_PSB = None, psb_account_usage
 
     # `stat` command strings
-    STAT_RESPONSE = "You've participated in **{}** matches."
+    STAT_RESPONSE = None, stat_response
+    STAT_NO_MATCHES = "You have not participated in any matches :frowning:."
+    STAT_TOTALS = "You've participated in **{}** matches, over **{}** hours!"
+    STAT_PARTNER_MATCH_COUNT = "<@{}> | {} matches"
 
     def __init__(self, string, embed=None):
         self.__string = string

--- a/display/strings.py
+++ b/display/strings.py
@@ -207,7 +207,7 @@ class AllStrings(Enum):
     USAGE_WRONG_FORMAT = "Incorrect format ``{}``, formatting must follow ``YYYY-MM-DD``. "
     USAGE_PSB = None, psb_account_usage
 
-    # `stat` command strings
+    # `stats` command strings
     STAT_RESPONSE = None, stat_response
     STAT_NO_MATCHES = "You have not participated in any matches :frowning:."
     STAT_TOTALS = "You've participated in **{}** matches, over **{}** hours!"

--- a/display/strings.py
+++ b/display/strings.py
@@ -207,6 +207,9 @@ class AllStrings(Enum):
     USAGE_WRONG_FORMAT = "Incorrect format ``{}``, formatting must follow ``YYYY-MM-DD``. "
     USAGE_PSB = None, psb_account_usage
 
+    # `stat` command strings
+    STAT_RESPONSE = "You've participated in **{}** matches."
+
     def __init__(self, string, embed=None):
         self.__string = string
         self.__embed = embed

--- a/modules/database.py
+++ b/modules/database.py
@@ -213,18 +213,6 @@ def find_elements(collection: str, query: dict, projection=None):
     return _collections[collection].find(query)
 
 
-def count_elements(collection: str, query: dict) -> int:
-    """
-    Count the elements in a collection.
-
-    :param collection: The name of the collection to count elements from.
-    :param query: A query document that selects which documents to count in the collection.
-        Can be an empty document to count all documents.
-    """
-
-    return _collections[collection].count_documents(query)
-
-
 def aggregate_fields(collection: str, query: list):
     """
     Aggregate a collection via query list, using keywords for $match, $group, $project dicts etc
@@ -237,3 +225,4 @@ def add_element(collection: str, doc):
     Add an element to a collection, with an unspecified object ID
     """
     _collections[collection].insert_one(doc)
+

--- a/modules/database.py
+++ b/modules/database.py
@@ -213,6 +213,18 @@ def find_elements(collection: str, query: dict, projection=None):
     return _collections[collection].find(query)
 
 
+def count_elements(collection: str, query: dict) -> int:
+    """
+    Count the elements in a collection.
+
+    :param collection: The name of the collection to count elements from.
+    :param query: A query document that selects which documents to count in the collection.
+        Can be an empty document to count all documents.
+    """
+
+    return _collections[collection].count_documents(query)
+
+
 def aggregate_fields(collection: str, query: list):
     """
     Aggregate a collection via query list, using keywords for $match, $group, $project dicts etc
@@ -225,4 +237,3 @@ def add_element(collection: str, doc):
     Add an element to a collection, with an unspecified object ID
     """
     _collections[collection].insert_one(doc)
-


### PR DESCRIPTION
This PR aims to introduce a root-level `stats` command, which retrieves information related to the matches a player has participated in.

- Unregistered users receive the standard 'please register' response.
- Players with recorded matches receive a response detailing:
  - the number of non-forfeited or timed-out matches they've played.
  - the total time (in hours) they've spent in these matches.
  - their (up to) top three most frequent dueling partners.
- Players with no matches are told as such.

All responses are ephemeral.

I apologise for the code quality; there's definitely stuff that could be cleaned up here and I think my unfamiliarity with Python has led to some unnecessary boilerplate. Any feedback would be much appreciated!

![image](https://user-images.githubusercontent.com/36981953/213860222-3eafb531-5c4a-443d-ac94-bd68cd1d395a.png)
![image](https://user-images.githubusercontent.com/36981953/213861010-077b22a8-9e9c-4c68-a52c-91669364b793.png)
